### PR TITLE
Add LineUp console game with special discs and save/load support

### DIFF
--- a/connect4/Game.cs
+++ b/connect4/Game.cs
@@ -1,0 +1,352 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace LineUp
+{
+    public enum DiscType
+    {
+        Ordinary,
+        Boring,
+        Magnetic
+    }
+
+    public enum PlayerId
+    {
+        One = 0,
+        Two = 1
+    }
+
+    public enum GameMode
+    {
+        HumanVsHuman,
+        HumanVsComputer
+    }
+
+    public class Player
+    {
+        public PlayerId Id { get; }
+        public bool IsComputer { get; }
+        public int Ordinary { get; set; }
+        public int Boring { get; set; }
+        public int Magnetic { get; set; }
+
+        public Player(PlayerId id, bool computer, int ordinary, int boring, int magnetic)
+        {
+            Id = id;
+            IsComputer = computer;
+            Ordinary = ordinary;
+            Boring = boring;
+            Magnetic = magnetic;
+        }
+
+        public bool HasDisc(DiscType type)
+        {
+            return type switch
+            {
+                DiscType.Ordinary => Ordinary > 0,
+                DiscType.Boring => Boring > 0,
+                DiscType.Magnetic => Magnetic > 0,
+                _ => false
+            };
+        }
+
+        public void UseDisc(DiscType type)
+        {
+            switch (type)
+            {
+                case DiscType.Ordinary: Ordinary--; break;
+                case DiscType.Boring: Boring--; break;
+                case DiscType.Magnetic: Magnetic--; break;
+            }
+        }
+    }
+
+    public class Game
+    {
+        public int Rows { get; }
+        public int Columns { get; }
+        public int ConnectN { get; }
+        public GameMode Mode { get; }
+
+        private readonly char[,] board;
+        private readonly Player[] players = new Player[2];
+        private int currentPlayerIndex = 0;
+        private readonly Random rng = new Random();
+
+        public Game(int rows, int columns, GameMode mode)
+        {
+            Rows = rows;
+            Columns = columns;
+            Mode = mode;
+            ConnectN = 4;
+            board = new char[Rows, Columns];
+            for (int r = 0; r < Rows; r++)
+                for (int c = 0; c < Columns; c++)
+                    board[r, c] = ' ';
+
+            int totalCells = rows * columns;
+            int perPlayer = totalCells / 2;
+            int specials = 2; // Boring and Magnetic
+            int ordinary = perPlayer - specials * 2; // two of each special
+            players[0] = new Player(PlayerId.One, mode == GameMode.HumanVsComputer ? false : false, ordinary, 2, 2);
+            players[1] = new Player(PlayerId.Two, mode == GameMode.HumanVsComputer, ordinary, 2, 2);
+        }
+
+        public Player CurrentPlayer => players[currentPlayerIndex];
+        public Player OtherPlayer => players[1 - currentPlayerIndex];
+
+        public void SwitchPlayer() => currentPlayerIndex = 1 - currentPlayerIndex;
+
+        public void DisplayBoard()
+        {
+            for (int r = Rows - 1; r >= 0; r--)
+            {
+                var sb = new StringBuilder();
+                for (int c = 0; c < Columns; c++)
+                {
+                    sb.Append('|');
+                    sb.Append(' ');
+                    sb.Append(board[r, c]);
+                    sb.Append(' ');
+                }
+                sb.Append('|');
+                Console.WriteLine(sb.ToString());
+            }
+        }
+
+        private char CharFor(Player player, DiscType type)
+        {
+            bool p1 = player.Id == PlayerId.One;
+            return type switch
+            {
+                DiscType.Ordinary => p1 ? '@' : '#',
+                DiscType.Boring => p1 ? 'B' : 'b',
+                DiscType.Magnetic => p1 ? 'M' : 'm',
+                _ => ' '
+            };
+        }
+
+        private bool IsPlayerChar(char c, PlayerId player)
+        {
+            return player == PlayerId.One ? c == '@' || c == 'B' || c == 'M' : c == '#' || c == 'b' || c == 'm';
+        }
+
+        public bool ColumnFull(int column)
+        {
+            return board[Rows - 1, column] != ' ';
+        }
+
+        private int FindRow(int column)
+        {
+            for (int r = 0; r < Rows; r++)
+            {
+                if (board[r, column] == ' ')
+                    return r;
+            }
+            return -1;
+        }
+
+        public bool DropDisc(Player player, DiscType type, int column, bool showFrames)
+        {
+            if (column < 0 || column >= Columns) return false;
+            if (!player.HasDisc(type)) return false;
+            if (ColumnFull(column)) return false;
+
+            int row = FindRow(column);
+            char discChar = CharFor(player, type);
+            board[row, column] = discChar;
+            player.UseDisc(type);
+            if (showFrames) DisplayBoard();
+
+            if (type == DiscType.Boring)
+            {
+                ApplyBoring(player, column, row);
+                if (showFrames) DisplayBoard();
+                row = 0;
+            }
+            else if (type == DiscType.Magnetic)
+            {
+                ApplyMagnetic(player, column, row);
+                if (showFrames) DisplayBoard();
+            }
+
+            bool win = CheckWin(row, column, player.Id);
+            return win;
+        }
+
+        private void ApplyBoring(Player player, int column, int row)
+        {
+            for (int r = 0; r < row; r++)
+            {
+                char existing = board[r, column];
+                if (existing == '@' || existing == '#' || existing == 'B' || existing == 'b' || existing == 'M' || existing == 'm')
+                {
+                    PlayerId owner = existing == '@' || existing == 'B' || existing == 'M' ? PlayerId.One : PlayerId.Two;
+                    players[(int)owner].Ordinary++;
+                }
+                board[r, column] = ' ';
+            }
+            board[row, column] = ' ';
+            board[0, column] = CharFor(player, DiscType.Boring);
+        }
+
+        private void ApplyMagnetic(Player player, int column, int row)
+        {
+            int target = -1;
+            for (int r = row - 1; r >= 0; r--)
+            {
+                if (IsPlayerChar(board[r, column], player.Id))
+                {
+                    target = r;
+                    break;
+                }
+            }
+            if (target != -1 && target < row - 1)
+            {
+                char below = board[target, column];
+                char above = board[target + 1, column];
+                board[target, column] = above;
+                board[target + 1, column] = below;
+            }
+        }
+
+        public bool CheckWin(int row, int column, PlayerId player)
+        {
+            int[][] dirs = new int[][]
+            {
+                new[] {1, 0}, // vertical
+                new[] {0, 1}, // horizontal
+                new[] {1, 1}, // diag1
+                new[] {1, -1} // diag2
+            };
+            foreach (var d in dirs)
+            {
+                int count = 1;
+                count += CountDir(row, column, d[0], d[1], player);
+                count += CountDir(row, column, -d[0], -d[1], player);
+                if (count >= ConnectN) return true;
+            }
+            return false;
+        }
+
+        private int CountDir(int row, int col, int dr, int dc, PlayerId player)
+        {
+            int r = row + dr;
+            int c = col + dc;
+            int count = 0;
+            while (r >= 0 && r < Rows && c >= 0 && c < Columns)
+            {
+                if (IsPlayerChar(board[r, c], player)) count++; else break;
+                r += dr; c += dc;
+            }
+            return count;
+        }
+
+        public bool BoardFull()
+        {
+            for (int c = 0; c < Columns; c++)
+                if (board[Rows - 1, c] == ' ') return false;
+            return true;
+        }
+
+        public void Save(string filename)
+        {
+            var state = new GameState
+            {
+                Rows = Rows,
+                Columns = Columns,
+                Board = Enumerable.Range(0, Rows).Select(r =>
+                    new string(Enumerable.Range(0, Columns).Select(c => board[r, c]).ToArray())).ToArray(),
+                Players = players.Select(p => new PlayerState
+                {
+                    Id = p.Id,
+                    IsComputer = p.IsComputer,
+                    Ordinary = p.Ordinary,
+                    Boring = p.Boring,
+                    Magnetic = p.Magnetic
+                }).ToArray(),
+                CurrentPlayer = currentPlayerIndex,
+                Mode = Mode
+            };
+            var json = JsonSerializer.Serialize(state, new JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(filename, json);
+        }
+
+        public static Game Load(string filename)
+        {
+            var json = File.ReadAllText(filename);
+            var state = JsonSerializer.Deserialize<GameState>(json);
+            if (state == null) throw new Exception("Invalid save file");
+            var game = new Game(state.Rows, state.Columns, state.Mode);
+            for (int r = 0; r < state.Rows; r++)
+                for (int c = 0; c < state.Columns; c++)
+                    game.board[r, c] = state.Board[r][c];
+            for (int i = 0; i < 2; i++)
+            {
+                game.players[i].Ordinary = state.Players[i].Ordinary;
+                game.players[i].Boring = state.Players[i].Boring;
+                game.players[i].Magnetic = state.Players[i].Magnetic;
+                game.players[i] = new Player(state.Players[i].Id, state.Players[i].IsComputer, state.Players[i].Ordinary, state.Players[i].Boring, state.Players[i].Magnetic);
+            }
+            game.currentPlayerIndex = state.CurrentPlayer;
+            return game;
+        }
+
+        // Computer move choosing
+        public bool ComputerTurn()
+        {
+            var player = CurrentPlayer;
+            var validCols = new List<int>();
+            for (int c = 0; c < Columns; c++)
+            {
+                if (!ColumnFull(c) && player.HasDisc(DiscType.Ordinary)) validCols.Add(c);
+            }
+            int chosen = -1;
+            foreach (var col in validCols)
+            {
+                int row = FindRow(col);
+                board[row, col] = CharFor(player, DiscType.Ordinary);
+                bool win = CheckWin(row, col, player.Id);
+                board[row, col] = ' ';
+                if (win)
+                {
+                    chosen = col;
+                    break;
+                }
+            }
+            if (chosen == -1 && validCols.Count > 0)
+            {
+                chosen = validCols[rng.Next(validCols.Count)];
+            }
+            if (chosen != -1)
+            {
+                return DropDisc(player, DiscType.Ordinary, chosen, true);
+            }
+            return false;
+        }
+
+        // game state classes for serialization
+        public class GameState
+        {
+            public int Rows { get; set; }
+            public int Columns { get; set; }
+            public string[] Board { get; set; }
+            public PlayerState[] Players { get; set; }
+            public int CurrentPlayer { get; set; }
+            public GameMode Mode { get; set; }
+        }
+
+        public class PlayerState
+        {
+            public PlayerId Id { get; set; }
+            public bool IsComputer { get; set; }
+            public int Ordinary { get; set; }
+            public int Boring { get; set; }
+            public int Magnetic { get; set; }
+        }
+    }
+}

--- a/connect4/Program.cs
+++ b/connect4/Program.cs
@@ -1,3 +1,198 @@
-﻿// See https://aka.ms/new-console-template for more information
+using System;
+using System.IO;
+using LineUp;
 
-Console.WriteLine("Hello, World!");
+class Program
+{
+    static void Main(string[] args)
+    {
+        if (args.Length > 0 && args[0] == "--test")
+        {
+            string sequence = args.Length > 1 ? args[1] : Console.ReadLine() ?? string.Empty;
+            RunTest(sequence);
+            return;
+        }
+
+        Console.WriteLine("Welcome to LineUp!");
+        Console.WriteLine("Load game? (y/n)");
+        string? choice = Console.ReadLine();
+        Game game;
+        if (choice != null && choice.Trim().ToLower() == "y")
+        {
+            Console.WriteLine("Enter filename:");
+            string? fname = Console.ReadLine();
+            if (fname != null && File.Exists(fname))
+                game = Game.Load(fname);
+            else
+            {
+                Console.WriteLine("File not found. Starting new game.");
+                game = StartNew();
+            }
+        }
+        else
+        {
+            game = StartNew();
+        }
+
+        PlayGame(game);
+    }
+
+    static Game StartNew()
+    {
+        Console.WriteLine("Select mode: 1) Human vs Human 2) Human vs Computer");
+        int modeSel = ReadInt(1, 2);
+        GameMode mode = modeSel == 1 ? GameMode.HumanVsHuman : GameMode.HumanVsComputer;
+
+        Console.WriteLine("Enter rows (>=6):");
+        int rows = ReadInt(6, 100);
+        Console.WriteLine("Enter columns (>=7 and >=rows):");
+        int cols;
+        while (true)
+        {
+            cols = ReadInt(7, 100);
+            if (cols >= rows) break;
+            Console.WriteLine("Columns must be >= rows");
+        }
+        return new Game(rows, cols, mode);
+    }
+
+    static int ReadInt(int min, int max)
+    {
+        while (true)
+        {
+            string? s = Console.ReadLine();
+            if (int.TryParse(s, out int v) && v >= min && v <= max)
+                return v;
+            Console.WriteLine($"Enter number between {min} and {max}");
+        }
+    }
+
+    static void PlayGame(Game game)
+    {
+        while (true)
+        {
+            var player = game.CurrentPlayer;
+            Console.WriteLine();
+            game.DisplayBoard();
+            if (player.IsComputer)
+            {
+                Console.WriteLine("Computer thinking...");
+                bool win = game.ComputerTurn();
+                if (win)
+                {
+                    game.DisplayBoard();
+                    Console.WriteLine($"Player {(int)player.Id + 1} wins!");
+                    return;
+                }
+                if (game.BoardFull())
+                {
+                    game.DisplayBoard();
+                    Console.WriteLine("It's a draw.");
+                    return;
+                }
+                game.SwitchPlayer();
+                continue;
+            }
+
+            Console.WriteLine($"Player {(int)player.Id + 1} turn. Enter move (e.g., O4, B3, M5) or 'save <file>' or 'help':");
+            string? input = Console.ReadLine();
+            if (input == null) continue;
+            input = input.Trim();
+            if (input.StartsWith("save"))
+            {
+                var parts = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2)
+                {
+                    game.Save(parts[1]);
+                    Console.WriteLine("Game saved.");
+                }
+                else Console.WriteLine("Usage: save filename");
+                continue;
+            }
+            if (input == "help")
+            {
+                ShowHelp();
+                continue;
+            }
+            if (input == "exit") return;
+            if (input.Length < 2)
+            {
+                Console.WriteLine("Invalid input");
+                continue;
+            }
+            char typeChar = input[0];
+            if (!int.TryParse(input.Substring(1), out int column))
+            {
+                Console.WriteLine("Invalid column");
+                continue;
+            }
+            DiscType type = ParseDiscType(typeChar);
+            bool win = game.DropDisc(player, type, column - 1, true);
+            if (!win && game.BoardFull())
+            {
+                game.DisplayBoard();
+                Console.WriteLine("It's a draw.");
+                return;
+            }
+            if (win)
+            {
+                game.DisplayBoard();
+                Console.WriteLine($"Player {(int)player.Id + 1} wins!");
+                return;
+            }
+            game.SwitchPlayer();
+        }
+    }
+
+    static DiscType ParseDiscType(char c)
+    {
+        return char.ToUpperInvariant(c) switch
+        {
+            'O' => DiscType.Ordinary,
+            'B' => DiscType.Boring,
+            'M' => DiscType.Magnetic,
+            _ => DiscType.Ordinary
+        };
+    }
+
+    static void ShowHelp()
+    {
+        Console.WriteLine("Commands:");
+        Console.WriteLine("O# - ordinary disc in column #");
+        Console.WriteLine("B# - boring disc in column # (removes column)");
+        Console.WriteLine("M# - magnetic disc in column # (lifts own disc)");
+        Console.WriteLine("save <file> - save game");
+        Console.WriteLine("help - show this help");
+        Console.WriteLine("exit - quit");
+    }
+
+    static void RunTest(string sequence)
+    {
+        var game = new Game(6, 7, GameMode.HumanVsHuman);
+        var moves = sequence.Split(',', StringSplitOptions.RemoveEmptyEntries);
+        foreach (var mv in moves)
+        {
+            var trimmed = mv.Trim();
+            if (trimmed.Length < 2) continue;
+            char typeChar = trimmed[0];
+            if (!int.TryParse(trimmed.Substring(1), out int col)) continue;
+            var player = game.CurrentPlayer;
+            DiscType type = ParseDiscType(typeChar);
+            bool win = game.DropDisc(player, type, col - 1, false);
+            if (win)
+            {
+                game.DisplayBoard();
+                Console.WriteLine($"Player {(int)player.Id + 1} wins.");
+                return;
+            }
+            if (game.BoardFull())
+            {
+                game.DisplayBoard();
+                Console.WriteLine("Draw.");
+                return;
+            }
+            game.SwitchPlayer();
+        }
+        game.DisplayBoard();
+    }
+}


### PR DESCRIPTION
## Summary
- implement LineUp gameplay engine with ordinary, boring, and magnetic discs
- add interactive console interface with save/load and test mode
- provide simple computer opponent and help menu

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb3ddcb108333b69c444a5c77aa39