### PR TITLE
Refine input handling and AI with single save slot

### DIFF
--- a/connect4/GameAlgo.cs
+++ b/connect4/GameAlgo.cs
@@ -7,7 +7,6 @@ namespace Connect4
     {
         public int Rows { get; }
         public int Columns { get; }
-        public int ConnectN { get; }
         public _GameMode Mode { get; }
 
         private readonly char[,] board;
@@ -20,7 +19,6 @@ namespace Connect4
             Rows = rows;
             Columns = columns;
             Mode = mode;
-            ConnectN = 4;
             board = RenderGrid.GenBoard(Rows, Columns);
 
             int totalCells = rows * columns;
@@ -154,7 +152,7 @@ namespace Connect4
                 if (match) count++; else break;
                 r--;
             }
-            if (count >= ConnectN) return true;
+            if (count >= 4) return true;
 
             count = 1;
             int c = column + 1;
@@ -173,7 +171,7 @@ namespace Connect4
                 if (match) count++; else break;
                 c--;
             }
-            if (count >= ConnectN) return true;
+            if (count >= 4) return true;
 
             count = 1;
             r = row + 1;
@@ -196,7 +194,7 @@ namespace Connect4
                 r--;
                 c--;
             }
-            if (count >= ConnectN) return true;
+            if (count >= 4) return true;
 
             count = 1;
             r = row + 1;
@@ -219,7 +217,7 @@ namespace Connect4
                 r--;
                 c++;
             }
-            return count >= ConnectN;
+            return count >= 4;
         }
 
         public bool BoardFull()

--- a/connect4/Testing.cs
+++ b/connect4/Testing.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Connect4
+{
+    public static class Testing
+    {
+        public static void Run(string sequence)
+        {
+            var game = new GameAlgo(6, 7, _GameMode.HumanVsHuman);
+            var moves = sequence.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            foreach (var mv in moves)
+            {
+                var trimmed = mv.Trim();
+                if (trimmed.Length < 2) continue;
+                char typeChar = trimmed[0];
+                if (!int.TryParse(trimmed.Substring(1), out int col)) continue;
+                var player = game.CurrentPlayer;
+                char up = char.ToUpperInvariant(typeChar);
+                _DiscType type;
+                if (up == 'O' || typeChar == '0') type = _DiscType.Ordinary;
+                else if (up == 'B') type = _DiscType.Boring;
+                else if (up == 'M') type = _DiscType.Magnetic;
+                else continue;
+                bool win = game.DropDisc(player, type, col - 1, false);
+                if (win)
+                {
+                    RenderGrid.PrintBoard(game.Board, game.Rows, game.Columns);
+                    Console.WriteLine($"Player {(int)player.Id + 1} wins.");
+                    return;
+                }
+                if (game.BoardFull())
+                {
+                    RenderGrid.PrintBoard(game.Board, game.Rows, game.Columns);
+                    Console.WriteLine("Draw.");
+                    return;
+                }
+                game.CurrentPlayerIndex = 1 - game.CurrentPlayerIndex;
+            }
+            RenderGrid.PrintBoard(game.Board, game.Rows, game.Columns);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- restrict ordinary discs to 'O' or '0' and simplify save command
- fix win checking to always require four-in-a-row
- add basic AI that plays immediate winning move when available
- move test runner into separate file

## Testing
- `dotnet build connect4/connect4.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c56ea0f294833390f171c7d3c4ae6d