### PR TITLE
Improve win detection and terminal UI

### DIFF
--- a/connect4/Testing.cs
+++ b/connect4/Testing.cs
@@ -21,11 +21,11 @@ namespace Connect4
                 else if (up == 'B') type = DiscType.Boring;
                 else if (up == 'M') type = DiscType.Magnetic;
                 else continue;
-                bool win = game.DiscFalls(player, type, col - 1, false);
-                if (win)
+                var winner = game.DiscFalls(player, type, col - 1);
+                if (winner.HasValue)
                 {
                     RenderGrid.PrintBoard(game.Board, game.Rows, game.Columns);
-                    Console.WriteLine($"Player {(int)player.Id + 1} wins.");
+                    Console.WriteLine($"Player {(int)winner.Value + 1} wins.");
                     return;
                 }
                 if (game.BoardFull())


### PR DESCRIPTION
## Summary
- Detect wins for both players after every move and return the winning player.
- Polish terminal experience with turn banners, divider lines, robust save/load messages, and boxed help menu.

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6564f8e088333a00f7fd8c638564d