### PR TITLE
feat: compute connect length from board size

### DIFF
--- a/connect4/GameAlgo.cs
+++ b/connect4/GameAlgo.cs
@@ -1,5 +1,6 @@
 
-using System.Text.Json; 
+using System;
+using System.Text.Json;
 
 namespace Connect4
 {
@@ -9,6 +10,7 @@ namespace Connect4
         public int Columns { get; }
         public GameMode Mode { get; }
         private readonly char[,] board;
+        public int ConnectN { get; }
         
         private readonly Player[] players = new Player[2]; 
         public int CurrentPlayerNumber = 0;
@@ -20,6 +22,7 @@ namespace Connect4
             Columns = columns;
             Mode = mode;
             board = RenderGrid.GenBoard(Rows, Columns);
+            ConnectN = Math.Max(4, (int)Math.Floor(rows * columns * 0.1));
 
             int total_cells = rows * columns;
             int discsPerplayer = total_cells / 2;
@@ -186,7 +189,7 @@ namespace Connect4
                 if (match) count++; else break;
                 r--;
             }
-            if (count >= 4) return true; 
+            if (count >= ConnectN) return true; 
             // horizontal check RTL
             count = 1;
             int c = column + 1;
@@ -206,7 +209,7 @@ namespace Connect4
                 if (match) count++; else break;
                 c--;
             }
-            if (count >= 4) return true;
+            if (count >= ConnectN) return true;
         // diag c down-right
             count = 1;
             r = row + 1;
@@ -231,7 +234,7 @@ namespace Connect4
                 c--;
             }
             // diagg c down left
-            if (count >= 4) return true;
+            if (count >= ConnectN) return true;
 
             count = 1;
             r = row + 1;
@@ -255,7 +258,7 @@ namespace Connect4
                 r--;
                 c++;
             }
-            return count >= 4;
+            return count >= ConnectN;
         }
 
         public bool BoardFull()

--- a/connect4/Program.cs
+++ b/connect4/Program.cs
@@ -88,6 +88,7 @@ class Program
         var rng = new Random();
         RenderGrid.PrintBoard(gameAlgo.Board, gameAlgo.Rows, gameAlgo.Columns);
         PrintStatus(gameAlgo);
+        Console.WriteLine($"Connect {gameAlgo.ConnectN} to win!");
         Console.WriteLine("-------------");
 
         while (true)


### PR DESCRIPTION
## Summary
- calculate connect length dynamically from board dimensions
- display target connect length at game start

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository signatures 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c65da129608333a6c8abc0033c66ec